### PR TITLE
Add supported PIDs for Ford Escape

### DIFF
--- a/signalsets/v3/default.json
+++ b/signalsets/v3/default.json
@@ -39,29 +39,13 @@
     "signals": [
       {"id": "ESCAPE_COOLANT_TEMP", "path": "Control", "fmt": { "len": 1, "max": 215, "min": -40, "unit": "celsius" }, "name": "Coolant Temp"}
     ]},
-    { "hdr": "720", "rax": "728", "cmd": {"22": "404C"}, "freq": 5,
-    "signals": [
-      {"id": "ESCAPE_TEST_ODO", "path": "Trips", "fmt": { "len": 24, "max": 1677721, "div": 10, "unit": "kilometers" }, "name": "Odometer (Instrument panel)", "suggestedMetric": "odometer"}
-    ]},
-    { "hdr": "760", "rax": "768", "cmd": {"22": "3201"}, "freq": 0.25,
-    "signals": [
-      {"id": "ESCAPE_TEST_STEER_ANGLE", "path": "Control", "fmt": { "len": 16, "max": 1638, "min": -1638, "div": 20, "add": -1638.4, "unit": "degrees" }, "name": "Steering wheel angle (ABS)", "description": "Positive is rotated to the left, negative is rotated to the right."}
-    ]},
-    { "hdr": "760", "rax": "768", "cmd": {"22": "3201"}, "freq": 0.25,
-    "signals": [
-      {"id": "ESCAPE_TEST_STEER_ANGLE", "path": "Control", "fmt": { "len": 16, "max": 1638, "min": -1638, "div": 20, "add": -1638.4, "unit": "degrees" }, "name": "Steering wheel angle (ABS)", "description": "Positive is rotated to the left, negative is rotated to the right."}
-    ]},
-  { "hdr": "764", "cmd": {"22": "A224"}, "freq": 0.25,
-    "signals": [
-      {"id": "ESCAPE_TEST_CC_TGT_VSS", "path": "Cruise control", "fmt": { "len": 16, "max": 736, "min": -736, "mul": 3.6, "div": 10, "sign": true, "unit": "kilometersPerHour" }, "name": "Target vehicle speed", "description": "The speed of the vehicle ahead of you."}
-    ]},
   { "hdr": "7DF", "cmd": {"22": "1E1C"}, "freq": 1,
     "signals": [
-      {"id": "ESCAPE_TEST_TOT", "path": "Transmission", "fmt": { "len": 16, "max": 255, "div": 16, "unit": "celsius" }, "name": "Transmission oil temperature"}
+      {"id": "ESCAPE_TOT", "path": "Transmission", "fmt": { "len": 16, "max": 255, "div": 16, "unit": "celsius" }, "name": "Transmission oil temperature"}
     ]},
   { "hdr": "7E0", "rax": "7E8", "cmd": {"22": "1E12"}, "freq": 2,
     "signals": [
-      {"id": "ESCAPE_TEST_GEAR", "path": "Transmission", "name": "Current gear", "description": "The automatic transmission gear.", "fmt": {"len": 8, "map": {
+      {"id": "ESCAPE_GEAR", "path": "Transmission", "name": "Current gear", "description": "The automatic transmission gear.", "fmt": {"len": 8, "map": {
             "1":  { "description": "First gear",   "value": "1" },
             "2":  { "description": "Second gear",  "value": "2" },
             "3":  { "description": "Third gear",   "value": "3" },
@@ -77,7 +61,7 @@
     ]},
   { "hdr": "7E0", "rax": "7E8", "cmd": {"22": "1E23"}, "freq": 2,
     "signals": [
-      {"id": "ESCAPE_TEST_GEAR_SHFT", "path": "Transmission", "name": "Shift gear", "fmt": {"len": 8, "map": {
+      {"id": "ESCAPE_GEAR_SHFT", "path": "Transmission", "name": "Shift gear", "fmt": {"len": 8, "map": {
             "10": { "description": "Manual",  "value": "MANUAL" },
             "46": { "description": "Drive",   "value": "DRIVE" },
             "50": { "description": "Neutral", "value": "NEUTRAL" },
@@ -85,18 +69,6 @@
             "70": { "description": "Park",    "value": "PARK" }
           }}
       }
-    ]},
-  { "hdr": "7E0", "rax": "7E8", "cmd": {"22": "F42F"}, "freq": 1,
-    "signals": [
-      {"id": "ESCAPE_TEST_FLI", "path": "Fuel", "fmt": { "len": 8, "max": 255, "mul": 100, "div": 255, "unit": "percent" }, "name": "Fuel level", "suggestedMetric": "fuelTankLevel"}
-    ]},
-    { "hdr": "7E2", "rax": "7EA", "fcm1": true, "dbg": true, "cmd": {"22": "DD04"}, "freq": 30,
-    "signals": [
-      {"id": "ESCAPE_TEST_IAT", "path": "Climate", "fmt": { "len": 8, "max": 215, "min": -40, "add": -40, "unit": "celsius" }, "name": "Interior temperature"}
-    ]},
-  { "hdr": "7E2", "rax": "7EA", "fcm1": true, "dbg": true, "cmd": {"22": "DD05"}, "freq": 30,
-    "signals": [
-      {"id": "ESCAPE_TEST_AAT", "path": "Climate", "fmt": { "len": 8, "max": 215, "min": -40, "add": -40, "unit": "celsius" }, "name": "Exterior temperature"}
     ]}
   ]
   }

--- a/signalsets/v3/default.json
+++ b/signalsets/v3/default.json
@@ -29,7 +29,7 @@
   ]},
 { "hdr": "726", "rax": "72E", "cmd": {"22": "DD01"}, "freq": 5,
   "signals": [
-    {"id": "ESCAPE_ODO", "path": "Trips", "fmt": { "len": 24, "max": 1677721, "unit": "kilometers" }, "name": "Odometer (Instrument panel)", "suggestedMetric": "odometer"}
+    {"id": "ESCAPE_ODO", "path": "Trips", "fmt": { "len": 24, "max": 16777215, "unit": "kilometers" }, "name": "Odometer (Instrument panel)", "suggestedMetric": "odometer"}
   ]},
 { "hdr": "760", "rax": "768", "cmd": {"22": "3201"}, "freq": 0.25,
   "signals": [

--- a/signalsets/v3/default.json
+++ b/signalsets/v3/default.json
@@ -1,39 +1,103 @@
 { "commands": [
-{ "hdr": "720", "rax": "728", "cmd": {"22": "6180"}, "freq": 5,
-  "signals": [
-    {"id": "ESCAPE_ODO", "path": "Trips", "fmt": { "len": 24, "max": 1677721, "div": 10, "unit": "kilometers" }, "name": "Odometer", "suggestedMetric": "odometer"}
-  ]},
-{ "hdr": "720", "rax": "728", "cmd": {"22": "6185"}, "freq": 1,
-  "signals": [
-    {"id": "ESCAPE_FLI", "path": "Fuel", "fmt": { "len": 8, "max": 100, "mul": 100, "div": 255, "unit": "percent" }, "name": "Fuel tank level", "suggestedMetric": "fuelTankLevel"}
-  ]},
-{ "hdr": "726", "rax": "72E", "cmd": {"22": "2813"}, "freq": 5,
-  "signals": [
-    {"id": "ESCAPE_TP_FL", "path": "Tires", "fmt": { "len": 16, "max": 3276, "div": 20, "unit": "psi" }, "name": "Front left tire pressure", "suggestedMetric": "frontLeftTirePressure"}
-  ]},
-{ "hdr": "726", "rax": "72E", "cmd": {"22": "2814"}, "freq": 5,
-  "signals": [
-    {"id": "ESCAPE_TP_FR", "path": "Tires", "fmt": { "len": 16, "max": 3276, "div": 20, "unit": "psi" }, "name": "Front right tire pressure", "suggestedMetric": "frontRightTirePressure"}
-  ]},
-{ "hdr": "726", "rax": "72E", "cmd": {"22": "2815"}, "freq": 5,
-  "signals": [
-    {"id": "ESCAPE_TP_RRO", "path": "Tires", "fmt": { "len": 16, "max": 3276, "div": 20, "unit": "psi" }, "name": "Rear right outer tire pressure", "suggestedMetric": "rearRightTirePressure"}
-  ]},
-{ "hdr": "726", "rax": "72E", "cmd": {"22": "2816"}, "freq": 5,
-  "signals": [
-    {"id": "ESCAPE_TP_RLO", "path": "Tires", "fmt": { "len": 16, "max": 3276, "div": 20, "unit": "psi" }, "name": "Rear left outer tire pressure", "suggestedMetric": "rearLeftTirePressure"}
-  ]},
-{ "hdr": "726", "rax": "72E", "cmd": {"22": "2817"}, "freq": 5,
-  "signals": [
-    {"id": "ESCAPE_TP_RRI", "path": "Tires", "fmt": { "len": 16, "max": 3276, "div": 20, "unit": "psi" }, "name": "Rear right inner tire pressure", "suggestedMetric": "rearRightTirePressure"}
-  ]},
-{ "hdr": "726", "rax": "72E", "cmd": {"22": "2818"}, "freq": 5,
-  "signals": [
-    {"id": "ESCAPE_TP_RLI", "path": "Tires", "fmt": { "len": 16, "max": 3276, "div": 20, "unit": "psi" }, "name": "Rear left inner tire pressure", "suggestedMetric": "rearLeftTirePressure"}
-  ]},
-{ "hdr": "760", "rax": "768", "cmd": {"22": "3201"}, "freq": 0.25,
-  "signals": [
-    {"id": "ESCAPE_STEER_ANGLE", "path": "Control", "fmt": { "len": 8, "max": 790, "min": -790, "mul": 6.25, "sign": true, "unit": "degrees" }, "name": "Steering wheel angle", "description": "Positive is rotated to the left, negative is rotated to the right."}
-  ]}
-]
-}
+  { "hdr": "720", "rax": "728", "cmd": {"22": "6180"}, "freq": 5,
+    "signals": [
+      {"id": "ESCAPE_ODO", "path": "Trips", "fmt": { "len": 24, "max": 1677721, "div": 10, "unit": "kilometers" }, "name": "Odometer", "suggestedMetric": "odometer"}
+    ]},
+  { "hdr": "720", "rax": "728", "cmd": {"22": "6185"}, "freq": 1,
+    "signals": [
+      {"id": "ESCAPE_FLI", "path": "Fuel", "fmt": { "len": 8, "max": 100, "mul": 100, "div": 255, "unit": "percent" }, "name": "Fuel tank level", "suggestedMetric": "fuelTankLevel"}
+    ]},
+  { "hdr": "726", "rax": "72E", "cmd": {"22": "2813"}, "freq": 5,
+    "signals": [
+      {"id": "ESCAPE_TP_FL", "path": "Tires", "fmt": { "len": 16, "max": 3276, "div": 20, "unit": "psi" }, "name": "Front left tire pressure", "suggestedMetric": "frontLeftTirePressure"}
+    ]},
+  { "hdr": "726", "rax": "72E", "cmd": {"22": "2814"}, "freq": 5,
+    "signals": [
+      {"id": "ESCAPE_TP_FR", "path": "Tires", "fmt": { "len": 16, "max": 3276, "div": 20, "unit": "psi" }, "name": "Front right tire pressure", "suggestedMetric": "frontRightTirePressure"}
+    ]},
+  { "hdr": "726", "rax": "72E", "cmd": {"22": "2815"}, "freq": 5,
+    "signals": [
+      {"id": "ESCAPE_TP_RRO", "path": "Tires", "fmt": { "len": 16, "max": 3276, "div": 20, "unit": "psi" }, "name": "Rear right outer tire pressure", "suggestedMetric": "rearRightTirePressure"}
+    ]},
+  { "hdr": "726", "rax": "72E", "cmd": {"22": "2816"}, "freq": 5,
+    "signals": [
+      {"id": "ESCAPE_TP_RLO", "path": "Tires", "fmt": { "len": 16, "max": 3276, "div": 20, "unit": "psi" }, "name": "Rear left outer tire pressure", "suggestedMetric": "rearLeftTirePressure"}
+    ]},
+  { "hdr": "726", "rax": "72E", "cmd": {"22": "2817"}, "freq": 5,
+    "signals": [
+      {"id": "ESCAPE_TP_RRI", "path": "Tires", "fmt": { "len": 16, "max": 3276, "div": 20, "unit": "psi" }, "name": "Rear right inner tire pressure", "suggestedMetric": "rearRightTirePressure"}
+    ]},
+  { "hdr": "726", "rax": "72E", "cmd": {"22": "2818"}, "freq": 5,
+    "signals": [
+      {"id": "ESCAPE_TP_RLI", "path": "Tires", "fmt": { "len": 16, "max": 3276, "div": 20, "unit": "psi" }, "name": "Rear left inner tire pressure", "suggestedMetric": "rearLeftTirePressure"}
+    ]},
+  { "hdr": "760", "rax": "768", "cmd": {"22": "3201"}, "freq": 0.25,
+    "signals": [
+      {"id": "ESCAPE_STEER_ANGLE", "path": "Control", "fmt": { "len": 8, "max": 790, "min": -790, "mul": 6.25, "sign": true, "unit": "degrees" }, "name": "Steering wheel angle", "description": "Positive is rotated to the left, negative is rotated to the right."}
+    ]},
+    { "hdr": "760",  "cmd": {"01": "05"}, "freq": 0.25,
+    "signals": [
+      {"id": "ESCAPE_COOLANT_TEMP", "path": "Control", "fmt": { "len": 1, "max": 215, "min": -40, "unit": "celsius" }, "name": "Coolant Temp"}
+    ]},
+    { "hdr": "720", "rax": "728", "cmd": {"22": "404C"}, "freq": 5,
+    "signals": [
+      {"id": "ESCAPE_TEST_ODO", "path": "Trips", "fmt": { "len": 24, "max": 1677721, "div": 10, "unit": "kilometers" }, "name": "Odometer (Instrument panel)", "suggestedMetric": "odometer"}
+    ]},
+    { "hdr": "760", "rax": "768", "cmd": {"22": "3201"}, "freq": 0.25,
+    "signals": [
+      {"id": "ESCAPE_TEST_STEER_ANGLE", "path": "Control", "fmt": { "len": 16, "max": 1638, "min": -1638, "div": 20, "add": -1638.4, "unit": "degrees" }, "name": "Steering wheel angle (ABS)", "description": "Positive is rotated to the left, negative is rotated to the right."}
+    ]},
+    { "hdr": "760", "rax": "768", "cmd": {"22": "3201"}, "freq": 0.25,
+    "signals": [
+      {"id": "ESCAPE_TEST_STEER_ANGLE", "path": "Control", "fmt": { "len": 16, "max": 1638, "min": -1638, "div": 20, "add": -1638.4, "unit": "degrees" }, "name": "Steering wheel angle (ABS)", "description": "Positive is rotated to the left, negative is rotated to the right."}
+    ]},
+  { "hdr": "764", "cmd": {"22": "A224"}, "freq": 0.25,
+    "signals": [
+      {"id": "ESCAPE_TEST_CC_TGT_VSS", "path": "Cruise control", "fmt": { "len": 16, "max": 736, "min": -736, "mul": 3.6, "div": 10, "sign": true, "unit": "kilometersPerHour" }, "name": "Target vehicle speed", "description": "The speed of the vehicle ahead of you."}
+    ]},
+  { "hdr": "7DF", "cmd": {"22": "1E1C"}, "freq": 1,
+    "signals": [
+      {"id": "ESCAPE_TEST_TOT", "path": "Transmission", "fmt": { "len": 16, "max": 255, "div": 16, "unit": "celsius" }, "name": "Transmission oil temperature"}
+    ]},
+  { "hdr": "7E0", "rax": "7E8", "cmd": {"22": "1E12"}, "freq": 2,
+    "signals": [
+      {"id": "ESCAPE_TEST_GEAR", "path": "Transmission", "name": "Current gear", "description": "The automatic transmission gear.", "fmt": {"len": 8, "map": {
+            "1":  { "description": "First gear",   "value": "1" },
+            "2":  { "description": "Second gear",  "value": "2" },
+            "3":  { "description": "Third gear",   "value": "3" },
+            "4":  { "description": "Fourth gear",  "value": "4" },
+            "5":  { "description": "Fifth gear",   "value": "5" },
+            "6":  { "description": "Sixth gear",   "value": "6" },
+            "7":  { "description": "Seventh gear", "value": "7" },
+            "8":  { "description": "Eighth gear",  "value": "8" },
+            "9":  { "description": "Ninth gear",   "value": "9" },
+            "10": { "description": "Tenth gear",   "value": "10" }
+          }}
+      }
+    ]},
+  { "hdr": "7E0", "rax": "7E8", "cmd": {"22": "1E23"}, "freq": 2,
+    "signals": [
+      {"id": "ESCAPE_TEST_GEAR_SHFT", "path": "Transmission", "name": "Shift gear", "fmt": {"len": 8, "map": {
+            "10": { "description": "Manual",  "value": "MANUAL" },
+            "46": { "description": "Drive",   "value": "DRIVE" },
+            "50": { "description": "Neutral", "value": "NEUTRAL" },
+            "60": { "description": "Reverse", "value": "REVERSE" },
+            "70": { "description": "Park",    "value": "PARK" }
+          }}
+      }
+    ]},
+  { "hdr": "7E0", "rax": "7E8", "cmd": {"22": "F42F"}, "freq": 1,
+    "signals": [
+      {"id": "ESCAPE_TEST_FLI", "path": "Fuel", "fmt": { "len": 8, "max": 255, "mul": 100, "div": 255, "unit": "percent" }, "name": "Fuel level", "suggestedMetric": "fuelTankLevel"}
+    ]},
+    { "hdr": "7E2", "rax": "7EA", "fcm1": true, "dbg": true, "cmd": {"22": "DD04"}, "freq": 30,
+    "signals": [
+      {"id": "ESCAPE_TEST_IAT", "path": "Climate", "fmt": { "len": 8, "max": 215, "min": -40, "add": -40, "unit": "celsius" }, "name": "Interior temperature"}
+    ]},
+  { "hdr": "7E2", "rax": "7EA", "fcm1": true, "dbg": true, "cmd": {"22": "DD05"}, "freq": 30,
+    "signals": [
+      {"id": "ESCAPE_TEST_AAT", "path": "Climate", "fmt": { "len": 8, "max": 215, "min": -40, "add": -40, "unit": "celsius" }, "name": "Exterior temperature"}
+    ]}
+  ]
+  }
+  

--- a/signalsets/v3/default.json
+++ b/signalsets/v3/default.json
@@ -1,74 +1,74 @@
 { "commands": [
+{ "hdr": "720", "rax": "728", "cmd": {"22": "6185"}, "freq": 1,
+  "signals": [
+    {"id": "ESCAPE_FLI", "path": "Fuel", "fmt": { "len": 8, "max": 100, "mul": 100, "div": 255, "unit": "percent" }, "name": "Fuel tank level", "suggestedMetric": "fuelTankLevel"}
+  ]},
+{ "hdr": "726", "rax": "72E", "cmd": {"22": "2813"}, "freq": 5,
+  "signals": [
+    {"id": "ESCAPE_TP_FL", "path": "Tires", "fmt": { "len": 16, "max": 3276, "div": 20, "unit": "psi" }, "name": "Front left tire pressure", "suggestedMetric": "frontLeftTirePressure"}
+  ]},
+{ "hdr": "726", "rax": "72E", "cmd": {"22": "2814"}, "freq": 5,
+  "signals": [
+    {"id": "ESCAPE_TP_FR", "path": "Tires", "fmt": { "len": 16, "max": 3276, "div": 20, "unit": "psi" }, "name": "Front right tire pressure", "suggestedMetric": "frontRightTirePressure"}
+  ]},
+{ "hdr": "726", "rax": "72E", "cmd": {"22": "2815"}, "freq": 5,
+  "signals": [
+    {"id": "ESCAPE_TP_RRO", "path": "Tires", "fmt": { "len": 16, "max": 3276, "div": 20, "unit": "psi" }, "name": "Rear right outer tire pressure", "suggestedMetric": "rearRightTirePressure"}
+  ]},
+{ "hdr": "726", "rax": "72E", "cmd": {"22": "2816"}, "freq": 5,
+  "signals": [
+    {"id": "ESCAPE_TP_RLO", "path": "Tires", "fmt": { "len": 16, "max": 3276, "div": 20, "unit": "psi" }, "name": "Rear left outer tire pressure", "suggestedMetric": "rearLeftTirePressure"}
+  ]},
+{ "hdr": "726", "rax": "72E", "cmd": {"22": "2817"}, "freq": 5,
+  "signals": [
+    {"id": "ESCAPE_TP_RRI", "path": "Tires", "fmt": { "len": 16, "max": 3276, "div": 20, "unit": "psi" }, "name": "Rear right inner tire pressure", "suggestedMetric": "rearRightTirePressure"}
+  ]},
+{ "hdr": "726", "rax": "72E", "cmd": {"22": "2818"}, "freq": 5,
+  "signals": [
+    {"id": "ESCAPE_TP_RLI", "path": "Tires", "fmt": { "len": 16, "max": 3276, "div": 20, "unit": "psi" }, "name": "Rear left inner tire pressure", "suggestedMetric": "rearLeftTirePressure"}
+  ]},
 { "hdr": "726", "rax": "72E", "cmd": {"22": "DD01"}, "freq": 5,
   "signals": [
-    {"id": "ESCAPE_ODO", "path": "Trips", "fmt": { "len": 24, "max": 1677721, "div": 1, "unit": "kilometers" }, "name": "Odometer (Instrument panel)", "suggestedMetric": "odometer"}
+    {"id": "ESCAPE_ODO", "path": "Trips", "fmt": { "len": 24, "max": 1677721, "unit": "kilometers" }, "name": "Odometer (Instrument panel)", "suggestedMetric": "odometer"}
   ]},
-  { "hdr": "720", "rax": "728", "cmd": {"22": "6185"}, "freq": 1,
-    "signals": [
-      {"id": "ESCAPE_FLI", "path": "Fuel", "fmt": { "len": 8, "max": 100, "mul": 100, "div": 255, "unit": "percent" }, "name": "Fuel tank level", "suggestedMetric": "fuelTankLevel"}
-    ]},
-  { "hdr": "726", "rax": "72E", "cmd": {"22": "2813"}, "freq": 5,
-    "signals": [
-      {"id": "ESCAPE_TP_FL", "path": "Tires", "fmt": { "len": 16, "max": 3276, "div": 20, "unit": "psi" }, "name": "Front left tire pressure", "suggestedMetric": "frontLeftTirePressure"}
-    ]},
-  { "hdr": "726", "rax": "72E", "cmd": {"22": "2814"}, "freq": 5,
-    "signals": [
-      {"id": "ESCAPE_TP_FR", "path": "Tires", "fmt": { "len": 16, "max": 3276, "div": 20, "unit": "psi" }, "name": "Front right tire pressure", "suggestedMetric": "frontRightTirePressure"}
-    ]},
-  { "hdr": "726", "rax": "72E", "cmd": {"22": "2815"}, "freq": 5,
-    "signals": [
-      {"id": "ESCAPE_TP_RRO", "path": "Tires", "fmt": { "len": 16, "max": 3276, "div": 20, "unit": "psi" }, "name": "Rear right outer tire pressure", "suggestedMetric": "rearRightTirePressure"}
-    ]},
-  { "hdr": "726", "rax": "72E", "cmd": {"22": "2816"}, "freq": 5,
-    "signals": [
-      {"id": "ESCAPE_TP_RLO", "path": "Tires", "fmt": { "len": 16, "max": 3276, "div": 20, "unit": "psi" }, "name": "Rear left outer tire pressure", "suggestedMetric": "rearLeftTirePressure"}
-    ]},
-  { "hdr": "726", "rax": "72E", "cmd": {"22": "2817"}, "freq": 5,
-    "signals": [
-      {"id": "ESCAPE_TP_RRI", "path": "Tires", "fmt": { "len": 16, "max": 3276, "div": 20, "unit": "psi" }, "name": "Rear right inner tire pressure", "suggestedMetric": "rearRightTirePressure"}
-    ]},
-  { "hdr": "726", "rax": "72E", "cmd": {"22": "2818"}, "freq": 5,
-    "signals": [
-      {"id": "ESCAPE_TP_RLI", "path": "Tires", "fmt": { "len": 16, "max": 3276, "div": 20, "unit": "psi" }, "name": "Rear left inner tire pressure", "suggestedMetric": "rearLeftTirePressure"}
-    ]},
-  { "hdr": "760", "rax": "768", "cmd": {"22": "3201"}, "freq": 0.25,
-    "signals": [
-      {"id": "ESCAPE_STEER_ANGLE", "path": "Control", "fmt": { "len": 8, "max": 790, "min": -790, "mul": 6.25, "sign": true, "unit": "degrees" }, "name": "Steering wheel angle", "description": "Positive is rotated to the left, negative is rotated to the right."}
-    ]},
-    { "hdr": "760",  "cmd": {"01": "05"}, "freq": 0.25,
-    "signals": [
-      {"id": "ESCAPE_COOLANT_TEMP", "path": "Control", "fmt": { "len": 1, "max": 215, "min": -40, "unit": "celsius" }, "name": "Coolant Temp"}
-    ]},
-  { "hdr": "7DF", "cmd": {"22": "1E1C"}, "freq": 1,
-    "signals": [
-      {"id": "ESCAPE_TOT", "path": "Transmission", "fmt": { "len": 16, "max": 255, "div": 16, "unit": "celsius" }, "name": "Transmission oil temperature"}
-    ]},
-  { "hdr": "7E0", "rax": "7E8", "cmd": {"22": "1E12"}, "freq": 2,
-    "signals": [
-      {"id": "ESCAPE_GEAR", "path": "Transmission", "name": "Current gear", "description": "The automatic transmission gear.", "fmt": {"len": 8, "map": {
-            "1":  { "description": "First gear",   "value": "1" },
-            "2":  { "description": "Second gear",  "value": "2" },
-            "3":  { "description": "Third gear",   "value": "3" },
-            "4":  { "description": "Fourth gear",  "value": "4" },
-            "5":  { "description": "Fifth gear",   "value": "5" },
-            "6":  { "description": "Sixth gear",   "value": "6" },
-            "7":  { "description": "Seventh gear", "value": "7" },
-            "8":  { "description": "Eighth gear",  "value": "8" },
-            "9":  { "description": "Ninth gear",   "value": "9" },
-            "10": { "description": "Tenth gear",   "value": "10" }
-          }}
-      }
-    ]},
-  { "hdr": "7E0", "rax": "7E8", "cmd": {"22": "1E23"}, "freq": 2,
-    "signals": [
-      {"id": "ESCAPE_GEAR_SHFT", "path": "Transmission", "name": "Shift gear", "fmt": {"len": 8, "map": {
-            "10": { "description": "Manual",  "value": "MANUAL" },
-            "46": { "description": "Drive",   "value": "DRIVE" },
-            "50": { "description": "Neutral", "value": "NEUTRAL" },
-            "60": { "description": "Reverse", "value": "REVERSE" },
-            "70": { "description": "Park",    "value": "PARK" }
-          }}
-      }
-    ]}
-  ]
-  }
+{ "hdr": "760", "cmd": {"01": "05"}, "freq": 0.25,
+  "signals": [
+    {"id": "ESCAPE_COOLANT_TEMP", "path": "Control", "fmt": { "len": 1, "max": 215, "min": -40, "unit": "celsius" }, "name": "Coolant Temp"}
+  ]},
+{ "hdr": "760", "rax": "768", "cmd": {"22": "3201"}, "freq": 0.25,
+  "signals": [
+    {"id": "ESCAPE_STEER_ANGLE", "path": "Control", "fmt": { "len": 8, "max": 790, "min": -790, "mul": 6.25, "sign": true, "unit": "degrees" }, "name": "Steering wheel angle", "description": "Positive is rotated to the left, negative is rotated to the right."}
+  ]},
+{ "hdr": "7DF", "cmd": {"22": "1E1C"}, "freq": 1,
+  "signals": [
+    {"id": "ESCAPE_TOT", "path": "Transmission", "fmt": { "len": 16, "max": 255, "div": 16, "unit": "celsius" }, "name": "Transmission oil temperature"}
+  ]},
+{ "hdr": "7E0", "rax": "7E8", "cmd": {"22": "1E12"}, "freq": 2,
+  "signals": [
+    {"id": "ESCAPE_GEAR", "path": "Transmission", "name": "Current gear", "description": "The automatic transmission gear.", "fmt": {"len": 8, "map": {
+          "1":  { "description": "First gear",   "value": "1" },
+          "2":  { "description": "Second gear",  "value": "2" },
+          "3":  { "description": "Third gear",   "value": "3" },
+          "4":  { "description": "Fourth gear",  "value": "4" },
+          "5":  { "description": "Fifth gear",   "value": "5" },
+          "6":  { "description": "Sixth gear",   "value": "6" },
+          "7":  { "description": "Seventh gear", "value": "7" },
+          "8":  { "description": "Eighth gear",  "value": "8" },
+          "9":  { "description": "Ninth gear",   "value": "9" },
+          "10": { "description": "Tenth gear",   "value": "10" }
+        }}
+    }
+  ]},
+{ "hdr": "7E0", "rax": "7E8", "cmd": {"22": "1E23"}, "freq": 2,
+  "signals": [
+    {"id": "ESCAPE_GEAR_SHFT", "path": "Transmission", "name": "Shift gear", "fmt": {"len": 8, "map": {
+          "10": { "description": "Manual",  "value": "MANUAL" },
+          "46": { "description": "Drive",   "value": "DRIVE" },
+          "50": { "description": "Neutral", "value": "NEUTRAL" },
+          "60": { "description": "Reverse", "value": "REVERSE" },
+          "70": { "description": "Park",    "value": "PARK" }
+        }}
+    }
+  ]}
+]
+}

--- a/signalsets/v3/default.json
+++ b/signalsets/v3/default.json
@@ -1,11 +1,7 @@
 { "commands": [
-  { "hdr": "720", "rax": "728", "cmd": {"22": "6180"}, "freq": 5,
-    "signals": [
-      {"id": "ESCAPE_ODO", "path": "Trips", "fmt": { "len": 24, "max": 1677721, "div": 10, "unit": "kilometers" }, "name": "Odometer", "suggestedMetric": "odometer"}
-    ]},
 { "hdr": "726", "rax": "72E", "cmd": {"22": "DD01"}, "freq": 5,
   "signals": [
-    {"id": "ESCAPE_ODO_2", "path": "Trips", "fmt": { "len": 24, "max": 1677721, "div": 1, "unit": "kilometers" }, "name": "Odometer (Instrument panel)", "suggestedMetric": "odometer"}
+    {"id": "ESCAPE_ODO", "path": "Trips", "fmt": { "len": 24, "max": 1677721, "div": 1, "unit": "kilometers" }, "name": "Odometer (Instrument panel)", "suggestedMetric": "odometer"}
   ]},
   { "hdr": "720", "rax": "728", "cmd": {"22": "6185"}, "freq": 1,
     "signals": [
@@ -76,4 +72,3 @@
     ]}
   ]
   }
-  

--- a/signalsets/v3/default.json
+++ b/signalsets/v3/default.json
@@ -31,10 +31,6 @@
   "signals": [
     {"id": "ESCAPE_ODO", "path": "Trips", "fmt": { "len": 24, "max": 1677721, "unit": "kilometers" }, "name": "Odometer (Instrument panel)", "suggestedMetric": "odometer"}
   ]},
-{ "hdr": "760", "cmd": {"01": "05"}, "freq": 0.25,
-  "signals": [
-    {"id": "ESCAPE_COOLANT_TEMP", "path": "Control", "fmt": { "len": 1, "max": 215, "min": -40, "unit": "celsius" }, "name": "Coolant Temp"}
-  ]},
 { "hdr": "760", "rax": "768", "cmd": {"22": "3201"}, "freq": 0.25,
   "signals": [
     {"id": "ESCAPE_STEER_ANGLE", "path": "Control", "fmt": { "len": 8, "max": 790, "min": -790, "mul": 6.25, "sign": true, "unit": "degrees" }, "name": "Steering wheel angle", "description": "Positive is rotated to the left, negative is rotated to the right."}

--- a/signalsets/v3/default.json
+++ b/signalsets/v3/default.json
@@ -3,6 +3,14 @@
     "signals": [
       {"id": "ESCAPE_ODO", "path": "Trips", "fmt": { "len": 24, "max": 1677721, "div": 10, "unit": "kilometers" }, "name": "Odometer", "suggestedMetric": "odometer"}
     ]},
+    { "hdr": "720", "rax": "728", "cmd": {"22": "404C"}, "freq": 5,
+  "signals": [
+    {"id": "ESCAPE_TEST_ODO_1", "path": "Trips", "fmt": { "len": 24, "max": 1677721, "div": 10, "unit": "kilometers" }, "name": "Odometer (Instrument panel)", "suggestedMetric": "odometer"}
+  ]},
+{ "hdr": "726", "rax": "72E", "cmd": {"22": "DD01"}, "freq": 5,
+  "signals": [
+    {"id": "ESCAPE_TEST_ODO_2", "path": "Trips", "fmt": { "len": 24, "max": 1677721, "div": 10, "unit": "kilometers" }, "name": "Odometer (Instrument panel)", "suggestedMetric": "odometer"}
+  ]},
   { "hdr": "720", "rax": "728", "cmd": {"22": "6185"}, "freq": 1,
     "signals": [
       {"id": "ESCAPE_FLI", "path": "Fuel", "fmt": { "len": 8, "max": 100, "mul": 100, "div": 255, "unit": "percent" }, "name": "Fuel tank level", "suggestedMetric": "fuelTankLevel"}

--- a/signalsets/v3/default.json
+++ b/signalsets/v3/default.json
@@ -3,13 +3,9 @@
     "signals": [
       {"id": "ESCAPE_ODO", "path": "Trips", "fmt": { "len": 24, "max": 1677721, "div": 10, "unit": "kilometers" }, "name": "Odometer", "suggestedMetric": "odometer"}
     ]},
-    { "hdr": "720", "rax": "728", "cmd": {"22": "404C"}, "freq": 5,
-  "signals": [
-    {"id": "ESCAPE_TEST_ODO_1", "path": "Trips", "fmt": { "len": 24, "max": 1677721, "div": 10, "unit": "kilometers" }, "name": "Odometer (Instrument panel)", "suggestedMetric": "odometer"}
-  ]},
 { "hdr": "726", "rax": "72E", "cmd": {"22": "DD01"}, "freq": 5,
   "signals": [
-    {"id": "ESCAPE_TEST_ODO_2", "path": "Trips", "fmt": { "len": 24, "max": 1677721, "div": 10, "unit": "kilometers" }, "name": "Odometer (Instrument panel)", "suggestedMetric": "odometer"}
+    {"id": "ESCAPE_ODO_2", "path": "Trips", "fmt": { "len": 24, "max": 1677721, "div": 1, "unit": "kilometers" }, "name": "Odometer (Instrument panel)", "suggestedMetric": "odometer"}
   ]},
   { "hdr": "720", "rax": "728", "cmd": {"22": "6185"}, "freq": 1,
     "signals": [


### PR DESCRIPTION
Added PIDs for Ford Escape, tested on 2018 1.5L Ecoboost.
22DD01 - Odometer
221E1C - The gear the car is in (Reports 1 unless switched to a different gear with side buttons on gear selector)
221E23 - The drive mode of the car (Park/Reverse/Neutral/Drive)